### PR TITLE
remove commented casper require line

### DIFF
--- a/create-goodbits-template.js
+++ b/create-goodbits-template.js
@@ -4,7 +4,6 @@
 - npm install
 - run `node create-goodbits-template.js --botemail="$GOODBITS_USER_EMAIL" --botpassword="$GOODBITS_USER_PASSWORD" --botblogurl="https://www.emberjs.com/blog/2018/11/16/the-ember-times-issue-73.html"
 - use the `--debug=true` for development */
-// let casper = require('casper').create();
 const puppeteer = require('puppeteer');
 const argv = require('yargs').argv
 


### PR DESCRIPTION
My assumption is that the commented line `let casper = ....` is probably obsolete at this point hence not needed so this PR is just a minor update to remove commented code out of the repo.